### PR TITLE
chore: エージェント向けドキュメントを整理し CLAUDE.md と copilot-instructions.md に統一

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,47 @@
+# Copilot code review instructions
+
+Small Python CLI: polls YouTube playlists (Data API v3) and posts a Discord
+embed per newly added video. No tests, linter, or CI exist. Prioritize
+correctness and secret-safety over style nits.
+
+## Review priorities
+
+- **Secrets and state must not be committed.** Flag any diff that adds real
+  values to `.env`, `playlists.json`, or `already.json`, or that removes those
+  entries from `.gitignore`. Only `sample.env` / `playlists.sample.json` may
+  contain placeholders.
+- **Preserve "announce once" idempotency.** State lives only in `already.json`.
+  Flag changes that could re-announce old videos, drop the dedup check
+  (`videoId in already[playlist]`), or write state before a video is actually
+  sent.
+- **Preserve the silent first run.** When a playlist is new (`init = True`),
+  its existing videos are recorded but not sent to Discord. Flag edits that
+  would notify the whole backlog on first run.
+- **Preserve the live/upcoming filter.** `get_videos_details` keeps only
+  `liveBroadcastContent == "none"`. Flag removal of this filter.
+- **API pagination.** YouTube calls use `list_next` loops; flag edits that read
+  only the first page.
+- **HTTP error handling.** `send_discord_message` and the YouTube calls do not
+  check for failures/rate limits. Raising this is welcome, but see non-issues
+  below before treating it as a blocker.
+- **Fatal-on-missing config** in `src/config.py` (`logger.critical` +
+  `exit(1)`) is intentional; do not suggest silently defaulting required keys.
+
+## Known non-issues (do not flag)
+
+- `str.format()` and `%` formatting instead of f-strings — this is the
+  established style; do not suggest converting.
+- Direct `requests` POST to the Discord REST API instead of a Discord library —
+  intentional and minimal.
+- `list[str]` type hints while the README says Python 3.6+ — the README is
+  stale; the code targets 3.9+. Flag the README, not the code.
+- `requirements.txt` being UTF-16 encoded is a pre-existing repo condition, not
+  introduced by a normal PR; only mention it if a PR touches that file.
+- Absence of a test suite / CI — known; do not request adding tests unless the
+  PR itself adds testable logic.
+
+## Conventions
+
+- Python, standard-library-first, `snake_case` functions.
+- Runtime files (`.env`, `playlists.json`, `already.json`, `logs/`) are
+  git-ignored and read from the current working directory at run time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+## Overview
+
+`youtube-playlist-video-checker` polls a list of YouTube playlists via the
+YouTube Data API v3 and posts a Discord embed for each newly added video.
+It is a small Python CLI intended to run periodically (e.g. via cron). State
+is kept in a local JSON file so each video is announced only once.
+
+## Development commands
+
+There is no build step, test suite, linter, or CI configured in this repo.
+
+- Install dependencies: `pip3 install -U -r requirements.txt`
+- Run: `python3 -m src` (executes `src/__main__.py:main`)
+
+Run from the repository root: at runtime the process reads `.env`,
+`playlists.json`, and `already.json` from the current working directory and
+writes logs under `logs/`.
+
+## Configuration (runtime, git-ignored)
+
+- `.env` (loaded by `python-dotenv` in `src/config.py`). Required keys, each
+  fatal if missing (`logger.critical` + `exit(1)`):
+  - `GOOGLE_TOKEN`: YouTube Data API v3 key.
+  - `DISCORD_TOKEN`: Discord bot token.
+  - `DISCORD_CHANNEL_ID`: target Discord channel ID.
+- `playlists.json`: JSON array of playlist IDs to check. See
+  `playlists.sample.json` for the shape.
+- `already.json`: state file written by the app, mapping each playlist ID to
+  the list of video IDs already announced. Do not hand-edit while running.
+
+`.env`, `playlists.json`, `already.json`, and `logs/` are all git-ignored;
+never commit real tokens or state.
+
+## Architecture
+
+- `src/__main__.py`: entry point. For each playlist it lists items
+  (`get_playlist_items`), diffs against `already.json`, fetches video details
+  (`get_videos_details`), and sends a Discord embed per new video.
+- `src/config.py`: loads `.env` and exposes `GOOGLE_TOKEN`, `DISCORD_TOKEN`,
+  `DISCORD_CHANNEL_ID` via `getKey`.
+- `src/__init__.py`: `init_logger` (stream + daily-rotating file handler under
+  `logs/`, 30 backups) and `send_discord_message` (raw POST to the Discord REST
+  API with a `Bot` token, not a library).
+
+## Behavioral rules to preserve
+
+- First run of a playlist is a silent baseline: when a playlist is not yet in
+  `already.json` (`init = True`), its existing videos are recorded but NOT sent
+  to Discord. This prevents announcing the entire backlog. Keep this guard.
+- Live/upcoming entries are intentionally excluded: `get_videos_details` only
+  keeps items whose `liveBroadcastContent == "none"`, so premieres and live
+  streams are not announced until they become regular videos.
+- Idempotency comes solely from `already.json`. Any change to when IDs are
+  appended must keep "announce exactly once" intact.
+
+## Coding conventions
+
+- Match the existing style: `snake_case` functions, standard-library-first,
+  `str.format()` / `%` formatting (do not churn these into f-strings).
+- YouTube API calls use `googleapiclient` with `list_next` pagination; preserve
+  the pagination loops when editing fetch logic.
+- Discord messages are sent by direct `requests` calls in `send_discord_message`
+  rather than a Discord library; keep new Discord logic going through it.
+- The code uses PEP 585 builtin generics (`list[str]`), so Python 3.9+ is
+  required despite the README saying 3.6+.
+
+## Documentation update rules
+
+- If you change dependencies, runtime files, or the run command, update both
+  `README.md` and this file. Note that `README.md` currently understates the
+  dependency set (see it listing only `requests`/`youtube-dl`).


### PR DESCRIPTION
## 概要

生成 AI エージェント向けドキュメントを `CLAUDE.md` と `.github/copilot-instructions.md` の 2 点に標準化する。本リポジトリにはどちらも存在しなかったため、実際のコード・設定を確認した上で新規作成した。

## 変更内容

- **`CLAUDE.md`(新規作成)**: リポジトリの実態に基づき記述。
  - 概要 / 実行コマンド(`pip3 install -U -r requirements.txt`、`python3 -m src`)。
  - ランタイム設定(`.env` の `GOOGLE_TOKEN` / `DISCORD_TOKEN` / `DISCORD_CHANNEL_ID`、`playlists.json`、状態ファイル `already.json`)。いずれも git 管理外。
  - アーキテクチャ(`src/__main__.py` / `src/config.py` / `src/__init__.py`)。
  - 保持すべき挙動: 初回実行のサイレントベースライン(`init=True` 時は通知しない)、ライブ/配信予定の除外(`liveBroadcastContent == "none"` のみ)、`already.json` による冪等性。
  - コーディング規約(`snake_case`、`str.format()`/`%`、`googleapiclient` のページネーション、Discord は `requests` 直叩き、PEP 585 により Python 3.9+ 必須)。
- **`.github/copilot-instructions.md`(新規作成)**: GitHub Copilot のコードレビュー観点に特化。シークレット/状態ファイルの誤コミット検知、冪等性・初回サイレント・ライブ除外の保護、既知の非問題(f-string 変換提案の抑止など)を明記(4000 文字制限を考慮し 2424 文字)。

削除対象の `AGENTS.md` / `GEMINI.md`、Codex/Gemini CLI 参照ルールは存在しなかったため対応なし。

## 参照した実態

- Python プロジェクト。エントリポイントは `python3 -m src`(`src/__main__.py:main`)。
- 依存(`requirements.txt`): `google-api-python-client~=2.29.0`、`python-dotenv~=0.19.1`、`youtube-dl>=2021.2.10`、`requests~=2.25.1`。
- テスト / lint / CI は未整備。
