### PR TITLE
chore: .worktreeinclude を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,4 @@
+.env
+playlists.json
+already.json
+config.json


### PR DESCRIPTION
## 概要

`.worktreeinclude` を新規追加し、git-ignore 対象だが実行時に必要な設定・状態ファイルを worktree 間で共有できるようにします。

## 追加したパターン

```
.env
playlists.json
already.json
config.json
```

## 根拠

- `.gitignore` に `.idea`, `venv`, `config.json`, `playlists.json`, `already.json`, `.env`, `logs/`, `output` が含まれている
- `src/config.py:1-7` で `load_dotenv(override=True)` により `.env` を読み込んでいる
- `src/__main__.py:53-59` でカレントディレクトリの `already.json`(状態)と `playlists.json`(設定)を `open()`/JSON パースで読み込んでいる
- `src/__main__.py:131` で更新後の `already.json` を書き込んでいる
- `sample.env` / `playlists.sample.json` というテンプレートファイルが同梱されている
- README.md に「`sample.env` を書き換えて `.env` にリネーム」「`playlists.sample.json` を書き換えて `playlists.json` にリネーム」という手順が記載されている

`config.json` は `.gitignore` には含まれているものの、`src/` や README では参照が見つからず、テンプレートファイルも存在しません。レガシーまたは未文書化の機能で使われている可能性があるため、念のため防御的にパターンへ含めています。

## 関連

- https://github.com/book000/book000/issues/132
